### PR TITLE
[DONT MERGE] Call onChange when menu item is selected

### DIFF
--- a/src/SuperSelectField.js
+++ b/src/SuperSelectField.js
@@ -250,7 +250,10 @@ class SelectField extends Component {
       const updatedValues = selectedItemExists
         ? selectedItems.filter(obj => !areEqual(obj.value, selectedItem.value))
         : selectedItems.concat(selectedItem)
-      this.setState({ selectedItems: updatedValues })
+      this.setState({ selectedItems: updatedValues }, () => {
+        // call onChange when a menu item is selected, this allows state to get updated outside of just closing the menu
+        this.props.onChange(this.state.selectedItems, this.props.name);
+      });
       this.clearTextField(() => this.focusTextField())
     } else {
       const updatedValue = areEqual(selectedItems, selectedItem) ? null : selectedItem


### PR DESCRIPTION
The current SelectField component will not call the onChange prop until the Popover is closed, which uses the Popover onRequestClose event. There are two issues we see with this approach:

1. The UI doesn't appear to be responding, so if the user selects something, it won't apply until the Popover is closed. If there is feedback to the user about what they have selected (like the list of countries selected in the examples) then the user won't see updates until the control is closed. It makes it appear the UI is out of sync since an option is clearly checked but not in the list. 

2. More importantly, the Popover onRequestClose can get fired AFTER more important events. Our use case is a Search button, where the user choses some criteria and then clicks 'Search'. However, if the Popover wasn't explicitly closed before the Search button is clicked, then the button callback gets fired first (which redirects the page) and the criteria in the Select is never applied. This creates a bad scenario where the user can choose items in the dropdown, but then they aren't applied if they simply click Search without closing the Popover first.

This pull request changes the behavior so the onChange event fires every time an item is selected. It solves the above two problems. Theoretically, the onChange callback could be removed from the closeMenu function, but that wasn't done to minimize changes. So the user would get onChange events whenever something is selected and whenever the menu closed, which shouldn't be harmful.