### PR TITLE
Added useLayerForClickAway property for Popover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # material-ui-superSelectField [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url] [![javascript style guide][standard-image]][standard-url]
-                               
+
 [npm-image]: https://img.shields.io/npm/v/material-ui-superselectfield.svg
 [npm-url]: https://npmjs.org/package/material-ui-superselectfield
 [downloads-image]: https://img.shields.io/npm/dm/material-ui-superselectfield.svg
@@ -29,7 +29,7 @@
 This component requires 4 dependencies :
 - react
 - react-dom
-- react-tap-event-plugin 
+- react-tap-event-plugin
 - material-ui  
 
 ... so make sure they are installed in your project, or install them as well ;)
@@ -60,6 +60,7 @@ injectTapEventPlugin()
 | elementHeight | number, number[] | 36 | Height in pixels of each option element. If elements have different heights, you can provide them in an array. |
 | showAutocompleteThreshold | number | 10 | Maximum number of options from which to display the autocomplete search field.<br> For example, if autoComplete textfield need to be disabled, just set this prop with a value higher than children length. |
 | autocompleteFilter | function | see below | Provide your own filtering parser. Default: case insensitive.<br>The search field will appear only if there are more than 10 children (see `showAutocompleteThreshold`).<br>By default, the parser will check for `label` props, 'value' otherwise. |
+| useLayerForClickAway | bool | false | If true, the popover dropdown will render on top of an invisible layer, which will prevent clicks to the underlying elements, and trigger an `onRequestClose('clickAway')` call. |
 ##### Note when setting value :
 if multiple is set, value must be at least an empty Array.  
 For single value mode, you can set value to null.  

--- a/lib/SuperSelectField.js
+++ b/lib/SuperSelectField.js
@@ -608,7 +608,8 @@ var SelectField = function (_Component2) {
           checkedIcon = _props2.checkedIcon,
           unCheckedIcon = _props2.unCheckedIcon,
           hoverColor = _props2.hoverColor,
-          checkPosition = _props2.checkPosition;
+          checkPosition = _props2.checkPosition,
+          useLayerForClickAway = _props2.useLayerForClickAway;
 
       // Default style depending on Material-UI context (muiTheme)
 
@@ -743,7 +744,7 @@ var SelectField = function (_Component2) {
             anchorEl: this.root,
             canAutoPosition: false,
             anchorOrigin: anchorOrigin,
-            useLayerForClickAway: false,
+            useLayerForClickAway: useLayerForClickAway,
             onRequestClose: this.closeMenu,
             style: { height: popoverHeight }
           },
@@ -921,7 +922,8 @@ SelectField.propTypes = {
   multiple: _propTypes2.default.bool,
   disabled: _propTypes2.default.bool,
   onChange: _propTypes2.default.func,
-  onAutoCompleteTyping: _propTypes2.default.func
+  onAutoCompleteTyping: _propTypes2.default.func,
+  useLayerForClickAway: _propTypes2.default.bool,
 };
 
 SelectField.defaultProps = {
@@ -946,7 +948,8 @@ SelectField.defaultProps = {
   value: null,
   onChange: function onChange() {},
   onAutoCompleteTyping: function onAutoCompleteTyping() {},
-  children: []
+  children: [],
+  useLayerForClickAway: false
 };
 
 exports.default = SelectField;


### PR DESCRIPTION
Allow usage of useLayerForClickAway property for the internal Popover used in material-ui-superselectfield. This is needed in IE to prevent the Popover from closing instantly.

- Added bool property useLayerForClickAway
- Updated README with new property