### PR TITLE
Update README after exposing canAutoPosition prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ In lieu of a formal style guide, take care to maintain the existing coding style
   Expose more props :
   - [x] noMatchFound message
   - [ ] floatingLabelText
-  - [ ] canAutoPosition
+  - [x] canAutoPosition
   - [x] checkPosition
   - [x] anchorOrigin
   - [ ] popoverStyle


### PR DESCRIPTION
#### What does this PR do?
- It completes the update on the README after the prop canAutoPosition has been exposed

#### Screenshots
![image](https://user-images.githubusercontent.com/26273354/29605079-845d6980-87e1-11e7-8148-3862a74417e3.png)
