### PR TITLE
Fix missing offset with single element height.

### DIFF
--- a/src/SuperSelectField.js
+++ b/src/SuperSelectField.js
@@ -517,7 +517,7 @@ class SelectField extends Component {
     const noMatchFoundHeight = 36
     const containerHeight = (Array.isArray(elementHeight)
       ? elementHeight.reduce((totalHeight, height) => totalHeight + height, 6)
-      : elementHeight * (nb2show < menuItems.length ? nb2show : menuItems.length)
+      : (elementHeight * (nb2show < menuItems.length ? nb2show : menuItems.length)) + 6
     ) || 0
     const popoverHeight = autoCompleteHeight + (containerHeight || noMatchFoundHeight) + footerHeight
     const scrollableStyle = { overflowY: nb2show >= menuItems.length ? 'hidden' : 'scroll' }


### PR DESCRIPTION
If you use an `elementHeight` that's an `Array` of `Number`s, you get an additional 6-pixel buffer to the `containerHeight`:
```JavaScript
elementHeight.reduce((totalHeight, height) => totalHeight + height, 6)
```
Note the `6` as the initial value of the call to `reduce()`. However, the corresponding branch for an `elementHeight` that’s just a single `Number` doesn’t have this offset:
```JavaScript
elementHeight * (nb2show < menuItems.length ? nb2show : menuItems.length)
```
This PR fixes that by adding the 6 pixels back in in the second case:
```JavaScript
(elementHeight * (nb2show < menuItems.length ? nb2show : menuItems.length)) + 6
```