### PR TITLE
Automatically Focus the AutoComplete when it Renders

### DIFF
--- a/src/SuperSelectField.js
+++ b/src/SuperSelectField.js
@@ -353,6 +353,7 @@ class SelectField extends Component {
               style={{ marginLeft: 16, marginBottom: 5, width: menuWidth - (16 * 2) }}
               underlineStyle={autocompleteUnderlineStyle}
               underlineFocusStyle={autocompleteUnderlineFocusStyle}
+              autoFocus
             />
           }
           <div


### PR DESCRIPTION
Fixes Sharlaan/material-ui-superselectfield#101

As an aside:
I was wondering if you'd be interested in a new feature I'd like to develop.
Add a new prop called `showMenu` or something that make more sense to you guys.
It will default to `auto` and will function exactly as before
But you can pass `always` so that the menu always shows regardless of how many items are in the list.

This is to support the ability make API calls based on the input of the autoComplete and dynamically load in list options.