### PR TITLE
Fix issue where ids of 0 would be ignored in itemsLength

### DIFF
--- a/src/SuperSelectField.test.js
+++ b/src/SuperSelectField.test.js
@@ -30,6 +30,10 @@ const testChildren = [
   <div key='1' value='2'>Test Child</div>
 ]
 
+const testChild = [
+  <div key='0' value='1'>Test Child</div>
+]
+
 describe('Default states, styles, and behaviors', () => {
   it('renders without crashing', () => {
     const root = document.createElement('div')
@@ -54,11 +58,24 @@ describe('Default states, styles, and behaviors', () => {
     expect(wrapper.find('Popover').props().open).toBe(true)
   })
 
+  it('expects the menu to open when clicked even with one child', () => {
+    const wrapper = shallowWithContext(<SuperSelectField>{testChild}</SuperSelectField>)
+    wrapper.simulate('click')
+    expect(wrapper.find('Popover').props().open).toBe(true)
+  })
+
   it('expects the menu to render children', () => {
     const wrapper = shallowWithContext(<SuperSelectField>{testChildren}</SuperSelectField>)
     wrapper.simulate('click') // opens menu
     const firstChild = wrapper.find('ListItem').first()
     expect(firstChild.props().primaryText).toBe(testChildren[0])
+  })
+
+  it('expects the menu to render even with one child', () => {
+    const wrapper = shallowWithContext(<SuperSelectField>{testChild}</SuperSelectField>)
+    wrapper.simulate('click') // opens menu
+    const firstChild = wrapper.find('ListItem').first()
+    expect(firstChild.props().primaryText).toBe(testChild[0])
   })
 
   it('should display [hintText] when nothing selected')

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,7 @@ export function getChildrenLength(children) {
           else if (typeof cpc === 'object' && cpc.props.value)++count
         }
       }
-      else if (value)++count
+      else if (value || value === 0) ++count
       return count
     }, 0)
   }


### PR DESCRIPTION
In the example/demos shown in the repo, they use `id`'s of `0` (which I suppose could be valid)
Anyway, I found a discrepancy where the menu wouldn't open if it had less than 2 items.
I found this strange and found that the util function `getChildrenLength()` had a reduce function that would count based on the 'value' of the child, in this case, this would be the `id`. Since the `id` was actually `0` it would count as a `false` and skip the count.

I've added a check specifically for `0` and it works as it should.

I've also added some tests for future use-cases.