### PR TITLE
Lower npm engine required

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/Sharlaan/material-ui-superselectfield.git"
   },
   "engines": {
-    "node": ">=8.9"
+    "node": ">=7"
   },
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@storybook/react": "^3.2.16",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.0",
-    "eslint": "^4.12.0",
+    "eslint": "3.19.0",
     "eslint-config-jonnybuchanan": "^5.0.1",
     "material-ui": "^0.19.4",
     "nwb": "^0.20.0",


### PR DESCRIPTION
- Updated `package.json` to work with **node engine** >=7
- Lower version of `eslint` from 4 back to 3 due to issue of `yarn lint`. [https://github.com/facebookincubator/create-react-app/issues/2528](https://github.com/facebookincubator/create-react-app/issues/2528)