### PR TITLE
Fixed error when sending null value

### DIFF
--- a/src/SelectionsPresenter.js
+++ b/src/SelectionsPresenter.js
@@ -26,7 +26,7 @@ const SelectionsPresenter = ({
 }) => {
   const { textField: { floatingLabelColor, borderColor, focusColor } } = muiTheme
 
-  const isValidObject = obj => Object.prototype.toString.call(obj) === '[object Object]' && Object.keys(obj).includes('value')
+  const isValidObject = obj => Object.prototype.toString.call(obj) === '[object Object]' && Object.keys(obj).includes('value') && obj.value !== null
   // Condition for shrinking the floating Label
   const isShrunk = (Array.isArray(selectedValues) && !!selectedValues.length) ||
     (!Array.isArray(selectedValues) && isValidObject(selectedValues)) ||


### PR DESCRIPTION
According to Material UI standards, when a input field has a empty/null value must show only the field label:

![screen shot 2017-12-06 at 19 39 41](https://user-images.githubusercontent.com/10898106/33686906-872ce29c-dabd-11e7-9c54-668116fafd98.png)

When focus, must show the hint text:

![screen shot 2017-12-06 at 19 39 49](https://user-images.githubusercontent.com/10898106/33686935-9b1bbe90-dabd-11e7-8de2-3044911f0b08.png)

And with a selected value:

![screen shot 2017-12-06 at 19 39 57](https://user-images.githubusercontent.com/10898106/33686958-a9b0e25a-dabd-11e7-8b29-85d9bf606cc1.png)

With material-ui-superselectfield, even when empty/null value, the hint text is show:

![screen shot 2017-12-06 at 19 46 01](https://user-images.githubusercontent.com/10898106/33687093-230a0ec4-dabe-11e7-8e2e-fe7231c11812.png)

This Pull Request fixes this error.
Before a value is selected:

![screen shot 2017-12-06 at 19 38 29](https://user-images.githubusercontent.com/10898106/33686989-c45c652a-dabd-11e7-99b3-673ddb43bd53.png)

After a value is selected:

![screen shot 2017-12-06 at 19 47 08](https://user-images.githubusercontent.com/10898106/33687138-522fa6aa-dabe-11e7-82fb-cd885de97907.png)



