### PR TITLE
Add new property onSelect

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ This component requires 3 dependencies :
 | keepSearchOnSelect | bool | false | Prevents the autocomplete field's value to be reset after each selection.|
 | disabled | bool | false | Include this property to disable superSelectField.|
 | value | null, object, object[] | null | Selected value(s).<br>/!\ REQUIRED: each object must expose a 'value' property. |
-| onChange | function | () => {} | Triggers when selecting/unselecting an option from the Menu.<br>signature: (selectedValues, name) with `selectedValues` array of selected values based on selected nodes' value property, and `name` the value of the superSelectField instance's name property |
+| onChange | function | () => {} | Triggers when closing the menu. Use this if you do not want to update your component state with each selection and only on menu close. <br>signature: (selectedValues, name) with `selectedValues` array of selected values based on selected nodes' value property, and `name` the value of the superSelectField instance's name property |
+| onSelect | function | () => {} | Triggers when selecting an item in the menu. Use this to update your componenet state with each selection from the menu (while still open). <br>signature: (selectedValues, name) with `selectedValues` array of selected values based on selected nodes' value property, and `name` the value of the superSelectField instance's name property |
 | onMenuOpen | function | () => {} | Triggers when opening the Menu. |
 | onAutoCompleteTyping | function | () => {} | Exposes the word typed in AutoComplete. Useful for triggering onType API requests. |
 | children | any | [] | Datasource is an array of any type of nodes, styled at your convenience.<br>/!\ REQUIRED: each node must expose a `value` property. This value property will be used by default for both option's value and label.<br>A `label` property can be provided to specify a different value than `value`. |

--- a/src/SuperSelectField.js
+++ b/src/SuperSelectField.js
@@ -78,6 +78,11 @@ class SelectField extends Component {
     })
   }
 
+  getSelected = () => {
+    const {onSelect, name} = this.props;
+    onSelection(this.state.selectedItems, name);
+  }
+
   openMenu() {
     if (!this.state.isOpen) this.props.onMenuOpen()
     if (this.state.itemsLength || this.props.showAutocompleteThreshold === 'always') this.setState({ isOpen: true }, () => this.focusTextField())
@@ -146,7 +151,7 @@ class SelectField extends Component {
       const updatedValues = selectedItemExists
         ? selectedItems.filter(obj => !areEqual(obj.value, selectedItem.value))
         : selectedItems.concat(selectedItem)
-      this.setState({ selectedItems: updatedValues })
+      this.setState({ selectedItems: updatedValues }, this.getSelected())
       this.clearTextField(() => this.focusTextField())
     }
     else {

--- a/src/SuperSelectField.js
+++ b/src/SuperSelectField.js
@@ -80,7 +80,7 @@ class SelectField extends Component {
 
   getSelected = () => {
     const {onSelect, name} = this.props;
-    onSelection(this.state.selectedItems, name);
+    onSelect(this.state.selectedItems, name);
   }
 
   openMenu() {

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -48,6 +48,7 @@ export const selectFieldDefaultProps = {
   },
   value: null,
   onChange: () => {},
+  onSelect: () => {},
   onMenuOpen: () => {},
   onAutoCompleteTyping: () => {},
   children: []

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -144,6 +144,7 @@ export const selectFieldTypes = {
   keepSearchOnSelect: bool,
   disabled: bool,
   onChange: func,
+  onSelect: func,
   onMenuOpen: func,
   onAutoCompleteTyping: func
 }


### PR DESCRIPTION
### Alternative to https://github.com/Sharlaan/material-ui-superselectfield/pull/23

### Intro

The current functionality of this component does not allow for developers to handle exactly what happens with their own application state with each selection of a menu item. 

The current behavior is such that `onChange` is only called when the menu is closed. This PR addresses this issue by adding `onSelect`


### onSelect

onSelect is used to expose the selected values each time the user selects or unselects a value from the menu item. It differs from `onChange` because it is called _every_ time the user makes a new selection. 

This will be useful because developers now have access to the entire selection state inside the select field every time the user interacts with it. 


### Use case 

A developer is using the select field in a `dialog`. 

The developer would like for the dialog to be able to apply the selection even while the menu is open.

With this new property it's now possible to always know what's selected and hence even if the dialog holding the select field closes, we can save and make request on the items selected.

### Side note

Any current consumers of this component will be unaffected by this change. But allows those for who desire it a little more control over how their applications can respond to this component 💯 

Thoughts and feedback welcome 👍 