### PR TITLE
Added popOverClassName prop to the PopOver Element

### DIFF
--- a/src/SuperSelectField.js
+++ b/src/SuperSelectField.js
@@ -225,6 +225,7 @@ class SelectField extends Component {
       nb2show,
       noMatchFound,
       noMatchFoundStyle,
+      popOverClassName,
       selectedMenuItemStyle,
       selectionsRenderer,
       style,
@@ -374,6 +375,7 @@ class SelectField extends Component {
           useLayerForClickAway={false}
           onRequestClose={this.closeMenu}
           style={{ height: popoverHeight }}
+          className={popOverClassName}
         >
           {this.state.showAutocomplete && (
             <TextField


### PR DESCRIPTION
This is a quick fix to the problem I'm having that I mentioned over here https://github.com/Sharlaan/material-ui-superselectfield/issues/139